### PR TITLE
Externalize all env vars into constants.py

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -23,7 +23,7 @@ def create_app() -> Quart:
 
     app = Quart(__name__)
 
-    origins = filter(None, os.getenv("CORS_ORIGINS", "*").split(","))
+    origins = filter(None, constants.CORS_ORIGINS.split(","))
     app = cors(app, allow_origin=list(origins))
 
     app.config.from_mapping(

--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from urllib.parse import urlparse, urlunsplit
 

--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -10,12 +10,8 @@ from src.utils import constants, custom_logging
 logger = custom_logging.setup_logging(__name__)
 
 
-def get_api_url():
-    return urlparse(os.getenv("SFKIT_API_URL"))
-
-
 def get_websocket_origin():
-    url = get_api_url()
+    url = urlparse(constants.SFKIT_API_URL)
     scheme = 'wss' if url.scheme == 'https' else 'ws'
     return urlunsplit((scheme, str(url.netloc), '', '', ''))
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -101,7 +101,6 @@ async def get_cli_user(req: Request) -> dict:
     auth_header = req.headers.get(AUTH_HEADER)
     if constants.TERRA:
         user = await _get_terra_user(auth_header)
-        logger.info("_get_terra_user: user=%s", user)
     else:
         db: firestore.AsyncClient = current_app.config["DATABASE"]
         user = (

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,10 +1,16 @@
-from copy import deepcopy
 import os
+
+FLASK_DEBUG = os.getenv("FLASK_DEBUG")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")
 
 TERRA = os.getenv("TERRA", "")
 SAM_API_URL = os.getenv("SAM_API_URL", "https://sam.dsde-dev.broadinstitute.org")
-APP_VERSION = os.getenv('APP_VERSION', '')
-BUILD_VERSION = os.getenv('BUILD_VERSION', '')
+SFKIT_API_URL = os.getenv("SFKIT_API_URL", "http://localhost:8080")
+CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
+APP_VERSION = os.getenv("APP_VERSION", "")
+BUILD_VERSION = os.getenv("BUILD_VERSION", "")
+CLOUD_RUN = os.getenv("CLOUD_RUN", "False")
+SERVICE_URL = os.getenv("SERVICE_URL", "")
 SERVER_GCP_PROJECT = "broad-cho-priv1"
 SERVER_REGION = "us-central1"
 SERVER_ZONE = f"{SERVER_REGION}-a"
@@ -15,13 +21,17 @@ GOOGLE_CLIENT_ID = (
     "419003787216-rcif34r976a9qm3818qgeqed7c582od6.apps.googleusercontent.com"
 )
 # these are used only when TERRA is NOT set
-AZURE_B2C_CLIENT_ID = os.getenv("AZURE_B2C_CLIENT_ID", "a605ffae-592a-4096-b029-78ba66b6d614") # public; used for authentication
-AZURE_B2C_JWKS_URL = os.getenv("AZURE_B2C_JWKS_URL", "https://sfkitdevb2c.b2clogin.com/sfkitdevb2c.onmicrosoft.com/discovery/v2.0/keys?p=B2C_1_signupsignin1")
+AZURE_B2C_CLIENT_ID = os.getenv(
+    "AZURE_B2C_CLIENT_ID", "a605ffae-592a-4096-b029-78ba66b6d614"
+)  # public; used for authentication
+AZURE_B2C_JWKS_URL = os.getenv(
+    "AZURE_B2C_JWKS_URL",
+    "https://sfkitdevb2c.b2clogin.com/sfkitdevb2c.onmicrosoft.com/discovery/v2.0/keys?p=B2C_1_signupsignin1",
+)
 
+FIREBASE_API_KEY = os.getenv("FIREBASE_API_KEY")
 FIREBASE_PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID", SERVER_GCP_PROJECT)
 FIRESTORE_DATABASE = os.getenv("FIRESTORE_DATABASE", "(default)")
-
-LOG_LEVEL=os.getenv("LOG_LEVEL", "DEBUG")
 
 MPCGWAS_SHARED_PARAMETERS = {
     "NUM_SNPS": {

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 
 FLASK_DEBUG = os.getenv("FLASK_DEBUG")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")

--- a/src/utils/custom_logging.py
+++ b/src/utils/custom_logging.py
@@ -8,7 +8,7 @@ from src.utils import constants
 
 def setup_logging(name: Optional[str] = None) -> logging.Logger:
     # If the environment variable is set to "True", we are running on Cloud Run
-    if os.environ.get("CLOUD_RUN", "False").lower() == "true":
+    if constants.TERRA or constants.CLOUD_RUN.lower() == "true":
         # Instantiate the Google Cloud Logging client
         client = gcp_logging.Client()
 

--- a/src/utils/custom_logging.py
+++ b/src/utils/custom_logging.py
@@ -1,13 +1,12 @@
 import logging
-import os
 from typing import Optional
+
 from google.cloud import logging as gcp_logging
 
 from src.utils import constants
 
 
 def setup_logging(name: Optional[str] = None) -> logging.Logger:
-    # If the environment variable is set to "True", we are running on Cloud Run
     if constants.TERRA or constants.CLOUD_RUN.lower() == "true":
         # Instantiate the Google Cloud Logging client
         client = gcp_logging.Client()

--- a/src/utils/google_cloud/google_cloud_compute.py
+++ b/src/utils/google_cloud/google_cloud_compute.py
@@ -31,12 +31,12 @@ class GoogleCloudCompute:
     def delete_everything(self) -> None:
         logger.info(f"Deleting gcp resources for study {self.study_id}...")
         # if the network doesn't exist, there's nothing to delete
-        try: 
+        try:
             self.compute.networks().get(project=self.gcp_project, network=self.network_name).execute()
         except Exception as e:
             logger.info(f"Cannot find network {self.network_name}; skipping deletion.")
             return
-        
+
         self.remove_conflicting_peerings()
 
         for instance in self.list_instances():
@@ -385,7 +385,7 @@ class GoogleCloudCompute:
             ]
         }
 
-        if "dev" in os.getenv("SERVICE_URL", ""):
+        if "dev" in constants.SERVICE_URL:
             metadata_config["items"].append({
                 'key': 'SFKIT_API_URL',
                 'value': "https://sfkit-website-dev-bhj5a4wkqa-uc.a.run.app/api" # TODO: find better way to do this

--- a/src/utils/google_cloud/google_cloud_secret_manager.py
+++ b/src/utils/google_cloud/google_cloud_secret_manager.py
@@ -1,17 +1,16 @@
 import asyncio
-import os
 
 from google.cloud import secretmanager
 
 from src.utils import constants
 
+_FIREBASE_API_KEY = constants.FIREBASE_API_KEY
 
 async def get_firebase_api_key() -> str:
-    firebase_api_key = os.environ.get("FIREBASE_API_KEY")
-    if not firebase_api_key:
-        firebase_api_key = await get_secret("FIREBASE_API_KEY")
-        os.environ.setdefault("FIREBASE_API_KEY", firebase_api_key)
-    return firebase_api_key
+    global _FIREBASE_API_KEY
+    if not _FIREBASE_API_KEY:
+        _FIREBASE_API_KEY = await get_secret("FIREBASE_API_KEY")
+    return _FIREBASE_API_KEY
 
 
 async def get_secret(name: str) -> str:

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import re
 import secrets
 import time
 from html import escape
@@ -9,10 +8,9 @@ from typing import Optional
 from google.cloud.firestore_v1 import DocumentReference
 from jinja2 import Template
 from python_http_client.exceptions import HTTPError
-from quart import current_app, g, jsonify, url_for
+from quart import current_app, g
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Email, Mail
-from werkzeug import Response
 
 from src.utils import constants, custom_logging
 from src.utils.google_cloud.google_cloud_compute import (GoogleCloudCompute,

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -188,7 +188,7 @@ def sanitize_path(path: str) -> str:
 
 def is_developer() -> bool:
     return (
-        os.environ.get("FLASK_DEBUG") == "development"
+        constants.FLASK_DEBUG == "development"
         and g.user
         and "id" in g.user
         and g.user["id"] == constants.DEVELOPER_USER_ID
@@ -297,7 +297,7 @@ def check_conditions(doc_ref_dict, user_id) -> str:
     if (
         not demo
         and "broad-cho-priv1" in gcp_project
-        and os.environ.get("FLASK_DEBUG") != "development"
+        and constants.FLASK_DEBUG != "development"
     ):
         return "This project ID is only allowed for a demo study. Please follow the instructions in the 'Configure Study' button to set up your own GCP project before running the protocol."
     if not demo and not data_path:

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -36,12 +36,11 @@ async def create_custom_token() -> Response:
         custom_token = await loop.run_in_executor(
             None, firebase_auth.create_custom_token, user_id
         )
-        firebase_api_key = await get_firebase_api_key()
         return (
             jsonify(
                 {
                     "customToken": custom_token.decode("utf-8"),
-                    "firebaseApiKey": firebase_api_key,
+                    "firebaseApiKey": await get_firebase_api_key(),
                     "firebaseProjectId": constants.FIREBASE_PROJECT_ID,
                     "firestoreDatabaseId": constants.FIRESTORE_DATABASE,
                 }

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -11,16 +11,12 @@ from src.api_utils import get_display_names, get_studies, is_valid_uuid
 from src.auth import authenticate, get_user_id
 from src.utils import constants, custom_logging
 from src.utils.generic_functions import add_notification, remove_notification
-from src.utils.google_cloud.google_cloud_secret_manager import get_firebase_api_key
+from src.utils.google_cloud.google_cloud_secret_manager import \
+    get_firebase_api_key
 from src.utils.google_cloud.google_cloud_storage import (
-    download_blob_to_bytes,
-    download_blob_to_filename,
-)
-from src.utils.studies_functions import (
-    add_file_to_zip,
-    check_conditions,
-    update_status_and_start_setup,
-)
+    download_blob_to_bytes, download_blob_to_filename)
+from src.utils.studies_functions import (add_file_to_zip, check_conditions,
+                                         update_status_and_start_setup)
 
 logger = custom_logging.setup_logging(__name__)
 bp = Blueprint("web", __name__, url_prefix="/api")


### PR DESCRIPTION
This PR moves all environment variables into `constants.py` module. This makes it easier to see which variables all code depends on.

Additionally, we use the same custom log setup for Terra as for Cloud Run