### PR TITLE
Revert to using dedicated APIException class

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,12 +8,12 @@ from quart_cors import cors
 from werkzeug.exceptions import HTTPException
 
 from src import cli, signaling, status
-from src.api_utils import handle_http_exception
 from src.auth import register_terra_service_account
 from src.utils import constants, custom_logging
 from src.web import participants, study, web
 
 logger = custom_logging.setup_logging(__name__)
+
 
 def create_app() -> Quart:
     if constants.TERRA:
@@ -49,8 +49,12 @@ def create_app() -> Quart:
             await register_terra_service_account()
 
     @app.errorhandler(HTTPException)
-    async def _handle_http_exception(e: HTTPException):
-        return handle_http_exception(e)
+    async def handle_exception(e: HTTPException):
+        res = e.get_response()
+        if e.description:
+            res.data = json.dumps({ "error": e.description })
+            res.content_type = "application/json"
+        return res
 
     return app
 

--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -2,18 +2,22 @@ import uuid
 from urllib.parse import urlparse, urlunsplit
 
 import httpx
-import werkzeug.exceptions
 from google.cloud.firestore_v1 import FieldFilter
 from quart import current_app
+from werkzeug.exceptions import HTTPException
 
 from src.utils import constants, custom_logging
 
 logger = custom_logging.setup_logging(__name__)
 
 
-class APIException(werkzeug.exceptions.HTTPException):
+class APIException(HTTPException):
     def __init__(self, res: httpx.Response):
-        super().__init__(description=str(res.read()), response=res)
+        if res.headers.get("content-type") == "application/json" and "message" in res.json():
+            desc = res.json()["message"]
+        else:
+            desc = str(res.read())
+        super().__init__(description=desc, response=res)
 
 
 def get_websocket_origin():

--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -1,14 +1,19 @@
-import json
 import uuid
 from urllib.parse import urlparse, urlunsplit
 
+import httpx
+import werkzeug.exceptions
 from google.cloud.firestore_v1 import FieldFilter
 from quart import current_app
-from werkzeug.exceptions import HTTPException
 
 from src.utils import constants, custom_logging
 
 logger = custom_logging.setup_logging(__name__)
+
+
+class APIException(werkzeug.exceptions.HTTPException):
+    def __init__(self, res: httpx.Response):
+        super().__init__(description=str(res.read()), response=res)
 
 
 def get_websocket_origin():
@@ -99,16 +104,3 @@ def is_valid_uuid(val):
         return True
     except ValueError:
         return False
-
-
-def handle_http_exception(e: HTTPException):
-    res = e.get_response()
-    error = e.description
-    if not error:
-        if res.content_type == "application/json":
-            error = res.json()
-            error = error["message"] if "message" in error else str(error)
-        else:
-            error = str(res.read())
-    res.data = json.dumps({"error": error})
-    return res

--- a/src/auth.py
+++ b/src/auth.py
@@ -10,9 +10,9 @@ from google.auth.transport.requests import Request as GAuthRequest
 from google.cloud import firestore
 from jwt import algorithms
 from quart import Request, Websocket, current_app, request
-from werkzeug.exceptions import HTTPException, Unauthorized
+from werkzeug.exceptions import Unauthorized
 
-from src.api_utils import add_user_to_db
+from src.api_utils import APIException, add_user_to_db
 from src.utils import constants, custom_logging
 
 logger = custom_logging.setup_logging(__name__)
@@ -108,7 +108,7 @@ async def register_terra_service_account():
     )
 
     if res.status_code not in (HTTPStatus.CREATED.value, HTTPStatus.CONFLICT.value):
-        raise HTTPException(response=res)
+        raise APIException(res)
     else:
         logger.info(res.json()["message"])
 

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -13,8 +13,8 @@ from python_http_client.exceptions import HTTPError
 from quart import current_app, g
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Email, Mail
-from werkzeug.exceptions import HTTPException
 
+from src.api_utils import APIException
 from src.auth import get_service_account_headers
 from src.utils import constants, custom_logging
 from src.utils.google_cloud.google_cloud_compute import (GoogleCloudCompute,
@@ -170,7 +170,7 @@ async def _terra_rawls_post(path: str, json: Dict[str, Any]):
             json=json,
         )
         if res.status_code != HTTPStatus.CREATED.value:
-            raise HTTPException(response=res)
+            raise APIException(res)
 
 
 async def submit_terra_workflow(study_id: str, _role: str) -> None:


### PR DESCRIPTION
Looks like we have to use this after all, in order to get the exceptions printed with the right description.