### PR TITLE
Fix WebSocket connection issues due to CORS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ pycparser==2.21
 PyJWT==2.8.0
 pyparsing==3.1.1
 python-http-client==3.3.7
-Quart==0.19.3
+Quart==0.19.4
 quart-cors==0.7.0
 requests==2.31.0
 rsa==4.9

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,7 @@ from quart_cors import cors
 from werkzeug.exceptions import HTTPException
 
 from src import cli, signaling, status
+from src.api_utils import get_websocket_origin
 from src.auth import register_terra_service_account
 from src.utils import constants, custom_logging
 from src.web import participants, study, web
@@ -26,7 +27,7 @@ def create_app() -> Quart:
     app = Quart(__name__)
 
     origins = filter(None, constants.CORS_ORIGINS.split(","))
-    app = cors(app, allow_origin=list(origins))
+    app = cors(app, allow_origin=list(origins) + [get_websocket_origin()])
 
     app.config.from_mapping(
         SECRET_KEY=secrets.token_hex(16),

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,5 @@
 import os
 import secrets
-from multiprocessing import current_process
 
 import firebase_admin
 from google.cloud import firestore
@@ -18,22 +17,17 @@ logger = custom_logging.setup_logging(__name__)
 
 
 def create_app() -> Quart:
-    app = Quart(__name__)
-
-    # exit early if this is not a worker process
-    # https://stackoverflow.com/a/74303441/2962507
-    if not current_process().daemon:
-        return app
-
     if constants.TERRA:
         logger.info("Creating app - on Terra")
     else:
         logger.info("Creating app - NOT on Terra")
 
+    initialize_firebase_app()
+
+    app = Quart(__name__)
+
     origins = filter(None, constants.CORS_ORIGINS.split(","))
     app = cors(app, allow_origin=list(origins) + [get_websocket_origin()])
-
-    initialize_firebase_app()
 
     app.config.from_mapping(
         SECRET_KEY=secrets.token_hex(16),

--- a/src/signaling.py
+++ b/src/signaling.py
@@ -4,9 +4,7 @@ from enum import Enum
 from typing import Dict, List
 
 from quart import Blueprint, Websocket, abort, current_app, websocket
-from quart_cors import websocket_cors
 
-from src.api_utils import get_websocket_origin
 from src.auth import get_cli_user, get_user_id
 from src.utils import constants, custom_logging
 
@@ -56,7 +54,6 @@ STUDY_ID_HEADER = "X-MPC-Study-ID"
 
 
 @bp.websocket("/ice")
-@websocket_cors(allow_origin=get_websocket_origin())
 async def ice_ws():
     user_id = await _get_user_id(websocket)
     if not user_id:


### PR DESCRIPTION
It turns out the culprit for WebSocket 400 error, at least locally and on dev.sfkit.org, was that `websocket_cors` function wasn't working as documented - it seems to have been ignored by `quart-cors` library completely, and instead it used the global CORS config for the entire app. So now, I just added the WebSocket origin to the list of regular CORS origins, and call it a day.

Remains to be tested if any other issues (like with Apache OAuth proxy configuration) need to be solved for Terra.