### PR TITLE
Fix downloads of result files

### DIFF
--- a/src/utils/google_cloud/google_cloud_storage.py
+++ b/src/utils/google_cloud/google_cloud_storage.py
@@ -31,32 +31,6 @@ def upload_blob_from_filename(bucket_name: str, source_file_name: str, destinati
     return True
 
 
-def download_blob_to_filename(bucket_name: str, source_blob_name: str, destination_file_name: str) -> bool:
-    """Download a blob from a Google Cloud Storage bucket and save it as a file.
-
-    :param bucket_name: The name of the GCS bucket.
-    :param source_blob_name: The name of the source blob in the GCS bucket.
-    :param destination_file_name: The path to the file where the blob will be saved.
-    :return: True if successful, False otherwise.
-    """
-    try:
-        storage_client = StorageClient()
-        bucket = storage_client.bucket(bucket_name)
-        blob = bucket.blob(source_blob_name)
-        blob.download_to_filename(destination_file_name)
-    except GoogleAPIError as e:
-        logger.error(
-            f"Error downloading blob {source_blob_name} from bucket {bucket_name} to file {destination_file_name}."
-        )
-        logger.error(e)
-        return False
-
-    logger.info(
-        f"Downloaded storage object {source_blob_name} from bucket {bucket_name} to file {destination_file_name}."
-    )
-    return True
-
-
 def upload_blob_from_file(bucket_name: str, file_storage: FileStorage, destination_blob_name: str) -> bool:
     """Upload a file to a Google Cloud Storage bucket using FileStorage.
 

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -5,7 +5,7 @@ import time
 from html import escape
 from http import HTTPStatus
 from string import Template
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 from google.cloud import firestore
@@ -210,11 +210,6 @@ async def generate_ports(doc_ref: AsyncDocumentReference, role: str) -> None:
 
     doc_ref_dict["personal_parameters"][user]["PORTS"]["value"] = ports_str
     await doc_ref.set(doc_ref_dict, merge=True)
-
-
-def add_file_to_zip(zip_file, filepath: str, archive_name: Optional[str] = None) -> None:
-    with open(filepath, "rb") as f:
-        zip_file.writestr(archive_name or os.path.basename(filepath), f.read())
 
 
 def sanitize_path(path: str) -> str:

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -1,7 +1,6 @@
 import asyncio
 import io
 import os
-import tempfile
 import zipfile
 from datetime import datetime
 


### PR DESCRIPTION
We remove interaction with the filesystem when downloading results from the bucket, and use in-memory bytes instead.

This both reduces the security risk and makes the service stateless, to be compatible with our stateless K8s deployments.