### PR TITLE
[SMC-23] Fix failure to send email due to from_email handling

### DIFF
--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -62,7 +62,7 @@ async def email(inviter: str, recipient: str, invitation_message: str, study_tit
         subject=f"sfkit: Invitation to join {study_title} study",
         html_content=html_content,
     )
-    message.add_bcc(doc_ref_dict.get("from_email", ""))
+    message.add_bcc(from_email)
 
     try:
         response = sg.send(message)


### PR DESCRIPTION
Last code adjustment for `from_email` (https://github.com/hcholab/sfkit-website/pull/127) missed a piece of code that adds BCC. This PR fixes that.

https://broadworkbench.atlassian.net/browse/SMC-23