### PR TITLE
[SMC-20] Replace setup_configuration with CREATE_VM personal param

### DIFF
--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -68,7 +68,7 @@ async def get_studies(private_filter=None) -> list:
         "private",
         "invited_participants",
         "study_type",
-        "setup_configuration",
+        "setup_configuration", # deprecated
         "demo",
     ]
     try:

--- a/src/utils/api_functions.py
+++ b/src/utils/api_functions.py
@@ -3,11 +3,11 @@ import time
 
 from google.cloud import firestore
 from google.cloud.firestore import AsyncClient, AsyncDocumentReference
-from studies_functions import is_create_vm
 
 from src.utils import custom_logging
 from src.utils.google_cloud.google_cloud_compute import (GoogleCloudCompute,
                                                          format_instance_name)
+from src.utils.studies_functions import is_create_vm
 
 logger = custom_logging.setup_logging(__name__)
 

--- a/src/utils/api_functions.py
+++ b/src/utils/api_functions.py
@@ -5,9 +5,9 @@ from google.cloud import firestore
 from google.cloud.firestore import AsyncClient, AsyncDocumentReference
 
 from src.utils import custom_logging
+from src.utils.generic_functions import is_create_vm
 from src.utils.google_cloud.google_cloud_compute import (GoogleCloudCompute,
                                                          format_instance_name)
-from src.utils.studies_functions import is_create_vm
 
 logger = custom_logging.setup_logging(__name__)
 

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -529,6 +529,7 @@ DEFAULT_USER_PARAMETERS = {
         "AUTH_KEY",
         "SEND_RESULTS",
         "RESULTS_PATH",
+        "CREATE_VM",
         "DELETE_VM",
     ],
 }

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -503,6 +503,11 @@ DEFAULT_USER_PARAMETERS = {
                 This could be in the same bucket as your data, or a different one.",
         "value": "",
     },
+    "CREATE_VM": {
+        "name": "Create VM",
+        "description": "Whether or not to automatically create a VM instance on protocol start.",
+        "value": "Yes",
+    },
     "DELETE_VM": {
         "name": "Delete VM",
         "description": "Whether or not to immediately and automatically delete the VM instance on protocol completion.",

--- a/src/utils/generic_functions.py
+++ b/src/utils/generic_functions.py
@@ -21,3 +21,10 @@ async def add_notification(notification: str, user_id: str, location: str = "not
     notifications: list[str] = doc_ref_dict.get(location, [])
     notifications.append(notification)
     await doc_ref.set({location: notifications}, merge=True)
+
+
+def is_create_vm(study: dict, participant: str) -> bool:
+    return study["personal_parameters"][participant].get("CREATE_VM", {
+        # for backwards compatibility with study-wide setup_configuration
+        "value": "Yes" if study.get("setup_configuration", "website") == "website" else "No"
+    })["value"] == "Yes"

--- a/src/utils/google_cloud/google_cloud_compute.py
+++ b/src/utils/google_cloud/google_cloud_compute.py
@@ -6,12 +6,12 @@ from typing import Optional
 import googleapiclient.discovery as googleapi
 import ipaddr
 from googleapiclient.errors import HttpError
-from studies_functions import is_create_vm
 from tenacity import retry
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
 from src.utils import constants, custom_logging
+from src.utils.studies_functions import is_create_vm
 
 logger = custom_logging.setup_logging(__name__)
 

--- a/src/utils/google_cloud/google_cloud_compute.py
+++ b/src/utils/google_cloud/google_cloud_compute.py
@@ -11,7 +11,7 @@ from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
 from src.utils import constants, custom_logging
-from src.utils.studies_functions import is_create_vm
+from src.utils.generic_functions import is_create_vm
 
 logger = custom_logging.setup_logging(__name__)
 

--- a/src/utils/google_cloud/google_cloud_compute.py
+++ b/src/utils/google_cloud/google_cloud_compute.py
@@ -6,6 +6,7 @@ from typing import Optional
 import googleapiclient.discovery as googleapi
 import ipaddr
 from googleapiclient.errors import HttpError
+from studies_functions import is_create_vm
 from tenacity import retry
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
@@ -71,18 +72,22 @@ class GoogleCloudCompute:
     def setup_networking(self, doc_ref_dict: dict, role: str) -> None:
         logger.info(f"Setting up networking for role {role}...")
         gcp_projects: list = [constants.SERVER_GCP_PROJECT]
-        gcp_projects.extend(
-            doc_ref_dict["personal_parameters"][participant]["GCP_PROJECT"]["value"]
-            for participant in doc_ref_dict["participants"]
-        )
+        gcp_projects_peerings: list = [constants.SERVER_GCP_PROJECT]
+
+        for username, participant in doc_ref_dict["participants"].items():
+            gcp_project = participant["GCP_PROJECT"]["value"]
+            gcp_projects.extend(gcp_project)
+
+            if is_create_vm(doc_ref_dict, username):
+                gcp_projects_peerings.extend(gcp_project)
 
         self.create_network_if_it_does_not_already_exist(doc_ref_dict)
         self.create_firewall(doc_ref_dict)
         self.remove_conflicting_peerings(gcp_projects)
         self.remove_conflicting_subnets(gcp_projects)
         self.create_subnet(role)
-        if doc_ref_dict["setup_configuration"] == "website":
-            self.create_peerings(gcp_projects)
+        if gcp_projects_peerings:
+            self.create_peerings(gcp_projects_peerings)
 
     def create_network_if_it_does_not_already_exist(self, doc_ref_dict: dict) -> None:
         networks: list = self.compute.networks().list(project=self.gcp_project).execute()["items"]

--- a/src/utils/schemas/create_study.py
+++ b/src/utils/schemas/create_study.py
@@ -2,7 +2,7 @@ create_study_schema = {
     "type": "object",
     "properties": {
         "study_type": {"type": "string", "pattern": "^[0-9a-zA-Z\\-]*$", "maxLength": 100},
-        "setup_configuration": {"type": "string", "pattern": "^[0-9a-zA-Z\\-]*$", "maxLength": 100},
+        "setup_configuration": {"type": "string", "pattern": "^[0-9a-zA-Z\\-]*$", "maxLength": 100, "deprecated": True}, # deprecated
         "title": {"type": "string", "pattern": "^[^<>]*$", "maxLength": 100},
         "demo_study": {"type": "boolean"},
         "private_study": {"type": "boolean"},
@@ -11,7 +11,6 @@ create_study_schema = {
     },
     "required": [
         "study_type",
-        "setup_configuration",
         "title",
         "demo_study",
         "private_study",

--- a/src/utils/schemas/parameters.py
+++ b/src/utils/schemas/parameters.py
@@ -87,6 +87,7 @@ default_user_parameters_properties = {
     # "AUTH_KEY":
     "SEND_RESULTS": {"type": "string", "enum": ["Yes", "No"]},
     "RESULTS_PATH": {"type": "string", "pattern": "^$|^[a-z0-9][a-z0-9._-]{2,62}/.+$"},
+    "CREATE_VM": {"type": "string", "enum": ["Yes", "No"]},
     "DELETE_VM": {"type": "string", "enum": ["Yes", "No"]},
 }
 

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -236,6 +236,13 @@ def is_participant(study) -> bool:
     )
 
 
+def is_create_vm(study, participant: str) -> bool:
+    return study["personal_parameters"][participant].get("CREATE_VM", {
+        # for backwards compatibility with study-wide setup_configuration
+        "value": "Yes" if study.get("setup_configuration", "website") == "website" else "No"
+    })["value"] == "Yes"
+
+
 async def is_study_title_unique(study_title: str, db) -> bool:
     study_ref = db.collection("studies").where("title", "==", study_title).limit(1).stream()
     async for _ in study_ref:

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -236,13 +236,6 @@ def is_participant(study) -> bool:
     )
 
 
-def is_create_vm(study, participant: str) -> bool:
-    return study["personal_parameters"][participant].get("CREATE_VM", {
-        # for backwards compatibility with study-wide setup_configuration
-        "value": "Yes" if study.get("setup_configuration", "website") == "website" else "No"
-    })["value"] == "Yes"
-
-
 async def is_study_title_unique(study_title: str, db) -> bool:
     study_ref = db.collection("studies").where("title", "==", study_title).limit(1).stream()
     async for _ in study_ref:

--- a/src/web/study.py
+++ b/src/web/study.py
@@ -81,14 +81,13 @@ async def create_study(user_id="") -> Response:
 
     data = validate_json(await request.json, create_study_schema)
     study_type = data.get("study_type") or ""
-    setup_configuration = data.get("setup_configuration")
     study_title = data.get("title") or ""
     demo = data.get("demo_study") or False
     private_study = data.get("private_study")
     description = data.get("description")
     study_information = data.get("study_information")
 
-    logger.info(f"Creating {study_type} study with {setup_configuration} configuration")
+    logger.info(f"Creating {study_type} study")
 
     if await study_title_already_exists(study_title):
         raise Conflict("Study title already exists")
@@ -103,7 +102,6 @@ async def create_study(user_id="") -> Response:
             "study_id": study_id,
             "title": study_title,
             "study_type": study_type,
-            "setup_configuration": setup_configuration,
             "private": private_study or demo,
             "demo": demo,
             "description": description,


### PR DESCRIPTION
This PR deprecates `setup_configuration` study attribute that controlled whether a study was created in "website" or "user" mode, meaning whether the VMs would be created automatically by sfkit portal ("website") or manually ("user"). This parameter was more relevant to pre-Terra sfkit deployment, but even for that we're switching the UX such that each participant can decide if they want the VM to be auto- or manually provisioned, and their choice is recorded in the new `CREATE_VM` personal parameter instead.

On Terra, `CREATE_VM` set to `Yes` indicates that sfkit WDL workflow will be submitted on behalf of the user when they start a protocol in sfkit UI. Otherwise (`No`), they need to provision a VM manually, such as through an interactive analysis VM on Terra, or another VM outside of Terra (in either case, they would need to manually run an sfkit CLI command on that VM to start the protocol).

Outside of Terra, `CREATE_VM` set to `Yes` indicates that sfkit service will create a GCE VM inside a user's GCP project. This is the existing functionality that's currently done when `setup_configuration` is set to `website`. A `No` indicates the same approach as on Terra though.

This is part of the ongoing epic to streamline workflow submission UX in [SMC-20](https://broadworkbench.atlassian.net/browse/SMC-20).

