### PR TITLE
[SMC-28] Improve protocol start validation

### DIFF
--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -506,7 +506,7 @@ DEFAULT_USER_PARAMETERS = {
     "CREATE_VM": {
         "name": "Create VM",
         "description": "Whether or not to automatically create a VM instance on protocol start.",
-        "value": "Yes",
+        "value": "No",
     },
     "DELETE_VM": {
         "name": "Delete VM",

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -265,13 +265,15 @@ def check_conditions(doc_ref_dict, user_id) -> str:
         return "Non-demo studies require at least 2 participants to run the protocol."
     if not demo and not num_inds:
         return "You have not set the number of individuals/rows in your data. Please click on the 'Study Parameters' button to set this value and any other parameters you wish to change before running the protocol."
+    if not is_create_vm(doc_ref_dict, user_id):
+        return ""
     if not gcp_project:
         return "Your GCP project ID is not set. Please follow the instructions in the 'Configure Study' button before running the protocol."
-    if not demo and "broad-cho-priv1" in gcp_project and constants.FLASK_DEBUG != "development":
+    if not demo and gcp_project == constants.SERVER_GCP_PROJECT and constants.FLASK_DEBUG != "development":
         return "This project ID is only allowed for a demo study. Please follow the instructions in the 'Configure Study' button to set up your own GCP project before running the protocol."
     if not demo and not data_path:
         return "Your data path is not set. Please follow the instructions in the 'Configure Study' button before running the protocol."
-    if is_create_vm(doc_ref_dict, user_id) and not GoogleCloudIAM().test_permissions(gcp_project):
+    if not GoogleCloudIAM().test_permissions(gcp_project):
         return "You have not given the website the necessary GCP permissions for the project you have entered. Please click on 'Configure Study' to double-check that your project ID is correct and that you have given the website the necessary permissions (and they are not expired) in that GCP project."
     return ""
 

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -19,6 +19,7 @@ from werkzeug.exceptions import BadRequest
 from src.api_utils import APIException, fetch_study
 from src.auth import get_service_account_headers
 from src.utils import constants, custom_logging
+from src.utils.generic_functions import is_create_vm
 from src.utils.google_cloud.google_cloud_compute import GoogleCloudCompute, format_instance_name
 from src.utils.google_cloud.google_cloud_iam import GoogleCloudIAM
 
@@ -284,6 +285,7 @@ async def update_status_and_start_setup(doc_ref, doc_ref_dict, study_id):
         statuses[user] = "setting up your vm instance"
         await doc_ref.set({"status": statuses}, merge=True)
 
-        asyncio.create_task(setup_gcp(doc_ref, str(role)))
+        if is_create_vm(doc_ref_dict, user):
+            asyncio.create_task(setup_gcp(doc_ref, str(role)))
 
         time.sleep(1)

--- a/src/utils/studies_functions.py
+++ b/src/utils/studies_functions.py
@@ -271,7 +271,7 @@ def check_conditions(doc_ref_dict, user_id) -> str:
         return "This project ID is only allowed for a demo study. Please follow the instructions in the 'Configure Study' button to set up your own GCP project before running the protocol."
     if not demo and not data_path:
         return "Your data path is not set. Please follow the instructions in the 'Configure Study' button before running the protocol."
-    if not GoogleCloudIAM().test_permissions(gcp_project):
+    if is_create_vm(doc_ref_dict, user_id) and not GoogleCloudIAM().test_permissions(gcp_project):
         return "You have not given the website the necessary GCP permissions for the project you have entered. Please click on 'Configure Study' to double-check that your project ID is correct and that you have given the website the necessary permissions (and they are not expired) in that GCP project."
     return ""
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -116,7 +116,6 @@ async def profile(user_id: str, target_user_id: str = "") -> Response:
 @authenticate
 async def start_protocol(user_id) -> Response:
     study_id = validate_uuid(request.args.get("study_id"))
-    dry_run = "dry_run" in request.args
     _, doc_ref, doc_ref_dict = await fetch_study(study_id, user_id)
     statuses = doc_ref_dict["status"]
 
@@ -124,7 +123,7 @@ async def start_protocol(user_id) -> Response:
         if message := check_conditions(doc_ref_dict, user_id):
             raise Conflict(message)
 
-        if dry_run:
+        if "dry_run" in request.args:
             return jsonify({"message": "Protocol would have started successfully"})
 
         statuses[user_id] = "ready to begin sfkit"

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -116,12 +116,16 @@ async def profile(user_id: str, target_user_id: str = "") -> Response:
 @authenticate
 async def start_protocol(user_id) -> Response:
     study_id = validate_uuid(request.args.get("study_id"))
+    dry_run = "dry_run" in request.args
     _, doc_ref, doc_ref_dict = await fetch_study(study_id, user_id)
     statuses = doc_ref_dict["status"]
 
     if statuses[user_id] == "":
         if message := check_conditions(doc_ref_dict, user_id):
             raise Conflict(message)
+
+        if dry_run:
+            return jsonify({"message": "Protocol would have started successfully"})
 
         statuses[user_id] = "ready to begin sfkit"
         await doc_ref.set({"status": statuses}, merge=True)


### PR DESCRIPTION
This PR adds validation checks when starting a protocol.

Namely, it now checks if `CREATE_VM` personal parameter is set to `Yes` for a given user, before attempting to check GCP values and permissions, or to create a VM on their behalf. On Terra, this value is always `No` so these actions are skipped.

Additionally, we add optional `dry_run` query param that prevents any changes and results in a pure validation of the protocol params.

https://broadworkbench.atlassian.net/browse/SMC-28